### PR TITLE
WIP: Support for channel buffers

### DIFF
--- a/buffer.test.ts
+++ b/buffer.test.ts
@@ -1,0 +1,26 @@
+import { Buffer } from './buffer.ts';
+import { Line } from './bufferLine.ts';
+import { getTermSize } from './getTermSize.ts';
+import { bgBlue, black, bgRgb24 } from 'https://deno.land/std/fmt/colors.ts';
+
+async function renderFrame(): Promise<void> {
+  const { lines, columns } = await getTermSize();
+
+  const buffer = new Buffer(columns, lines);
+
+  const time = new Line();
+  time.text = black(bgBlue(` ${new Date().toString()} `));
+  time.fillColour((str: string) => bgRgb24(str, { r: 44, g: 49, b: 58 }));
+  time.commit(buffer);
+
+  for (var i = 1; i <= 30; i++) {
+    const line = new Line();
+    line.text = `Sup, I know how to count to ${i.toString()}`;
+    line.commit(buffer);
+  }
+
+  buffer.render();
+  setTimeout(renderFrame, 1000);
+}
+
+renderFrame();

--- a/buffer.test.ts
+++ b/buffer.test.ts
@@ -3,24 +3,68 @@ import { Line } from './bufferLine.ts';
 import { getTermSize } from './getTermSize.ts';
 import { bgBlue, black, bgRgb24 } from 'https://deno.land/std/fmt/colors.ts';
 
+let scroll = 0;
+let renderTimer: number = -1;
+let buffer: Buffer | undefined;
+
 async function renderFrame(): Promise<void> {
   const { lines, columns } = await getTermSize();
 
-  const buffer = new Buffer(columns, lines);
+  buffer = new Buffer(columns, lines, scroll);
 
   const time = new Line();
   time.text = black(bgBlue(` ${new Date().toString()} `));
   time.fillColour((str: string) => bgRgb24(str, { r: 44, g: 49, b: 58 }));
   time.commit(buffer);
 
-  for (var i = 1; i <= 30; i++) {
+  for (var i = 1; i <= 40; i++) {
     const line = new Line();
     line.text = `Sup, I know how to count to ${i.toString()}`;
     line.commit(buffer);
   }
 
   buffer.render();
-  setTimeout(renderFrame, 1000);
+  renderTimer = setTimeout(renderFrame, 1000);
+}
+
+Deno.setRaw(0, true); // requires --unstable
+async function cli() {
+  let input: string = '';
+  while (true) {
+    const stdBuffer = new Uint8Array(6);
+    const read = await Deno.stdin.read(stdBuffer);
+    if (read == null) continue;
+
+    const char = new TextDecoder().decode(stdBuffer.subarray(0, read));
+
+    switch (char) {
+      // Exit with Ctrl+C
+      case '\u0003':
+      case 'q':
+        Deno.stdout.writeSync(new TextEncoder().encode(`\x1B[2J`));
+        console.log('\nGoodbye\n');
+        // TODO(timothycole): Don't leave this, gracefully clean-up instead
+        Deno.exit(0);
+      // Up arrow
+      case '\u001b[A':
+      case 'k':
+        if (scroll < (buffer?.lineHight || 0)) scroll += 1;
+        clearTimeout(renderTimer);
+        renderFrame();
+        break;
+      // Down arrow
+      case '\u001b[B':
+      case 'j':
+        if (scroll > 0) scroll -= 1;
+        clearTimeout(renderTimer);
+        renderFrame();
+        break;
+      default:
+        input += char;
+    }
+  }
 }
 
 renderFrame();
+await cli();
+clearTimeout(renderTimer);

--- a/buffer.ts
+++ b/buffer.ts
@@ -1,0 +1,71 @@
+import { Line } from './bufferLine.ts';
+
+export interface BufferOptions {
+  x: number;
+  y: number;
+  scroll: number;
+}
+
+export class Buffer {
+  private lines: string[] = [];
+  private options: BufferOptions;
+
+  private size: { width: number; height: number };
+
+  constructor(
+    width: number,
+    height: number,
+    options: BufferOptions = {
+      x: 0,
+      y: 0,
+      scroll: 0,
+    }
+  ) {
+    this.options = options;
+    this.size = { width, height };
+    this.lines.push(' '.repeat(this.width()));
+  }
+
+  public height(): number {
+    return this.size.height;
+  }
+
+  public width(): number {
+    return this.size.width;
+  }
+
+  public append(line: Line): Buffer {
+    this.lines.push(line.text);
+    return this;
+  }
+
+  // Check to see if the vertical space is full.
+  // If not fill it up!
+  public async fill(): Promise<Buffer> {
+    var fillHeight = this.height() - this.lines.length;
+    if (fillHeight > 0)
+      for await (const _ of new Array(fillHeight))
+        this.lines.push(' '.repeat(this.width()));
+    return this;
+  }
+
+  public async render(): Promise<void> {
+    await this.fill();
+    // Clear screen
+    Deno.stdout.writeSync(new TextEncoder().encode(`\x1B[2J`));
+
+    // Write buffer
+    this.lines.map((line) => {
+      Deno.stdout.writeSync(
+        new TextEncoder().encode(
+          `\x1B[${this.options.y};${this.options.x}H${line}\n`
+        )
+      );
+      this.options.y++;
+    });
+
+    Deno.stdout.writeSync(
+      new TextEncoder().encode(`\x1B[${this.options.y - 1};${this.options.x}H`)
+    );
+  }
+}

--- a/bufferLine.ts
+++ b/bufferLine.ts
@@ -1,0 +1,47 @@
+import { Buffer } from './buffer.ts';
+
+// https://github.com/chalk/ansi-regex/blob/master/license
+const ansiRegex = new RegExp(
+  [
+    '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+    '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))',
+  ].join('|'),
+  'g'
+);
+
+export class Line {
+  private content: string = '';
+  private colour: (str: string) => string = (str: string) => str;
+
+  constructor() {}
+
+  public set text(text: string) {
+    this.content += text;
+  }
+
+  public get text(): string {
+    return this.content;
+  }
+
+  public padding(width: number): Line {
+    this.content += new Array(width + 1).join(this.colour(' '));
+    return this;
+  }
+
+  private fill(buffer: Buffer): Line {
+    var fillWidth = buffer.width() - this.content.replace(ansiRegex, '').length;
+    if (fillWidth > 0) this.padding(fillWidth);
+    return this;
+  }
+
+  public fillColour(colour: (str: string) => string): Line {
+    this.colour = colour;
+    return this;
+  }
+
+  public commit(buffer: Buffer): Line {
+    this.fill(buffer);
+    buffer.append(this);
+    return this;
+  }
+}


### PR DESCRIPTION
This feature adds support for buffered messages.

Instead of using console.log we add lines to the buffer then our buffer class manages into the buffer.

- [x] Initial buffer support
- [x] Scrolling buffer support<sup>1</sup>
- [ ] Multi buffer tab support<sup>2</sup>
- [ ] Status line support<sup>2</sup>
- [ ] Input line support (type-able line at the button to compose messages and commands)

<sup>1</sup> Buffers start from the bottom up. Scroll position starts at 0 and works it's way to tty line height.
<sup>2</sup> Statically placed - does not move with scroll.